### PR TITLE
fix: fix a bug that flag.short doesn't work

### DIFF
--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -203,24 +203,28 @@ func setupApp(app *cli.App, flags *LDFlags) {
 }
 
 func newFlag(flag domain.Flag) cli.Flag {
-	name := flag.Name
-	if flag.Short != "" {
-		name += ", " + flag.Short
-	}
 	switch flag.Type {
 	case boolFlagType:
-		return &cli.BoolFlag{
-			Name:    name,
+		f := &cli.BoolFlag{
+			Name:    flag.Name,
 			Usage:   flag.Usage,
 			EnvVars: flag.InputEnvs,
 		}
+		if flag.Short != "" {
+			f.Aliases = []string{flag.Short}
+		}
+		return f
 	default:
-		return &cli.StringFlag{
-			Name:    name,
+		f := &cli.StringFlag{
+			Name:    flag.Name,
 			Usage:   flag.Usage,
 			Value:   flag.Default,
 			EnvVars: flag.InputEnvs,
 		}
+		if flag.Short != "" {
+			f.Aliases = []string{flag.Short}
+		}
+		return f
 	}
 }
 

--- a/pkg/handler/main_test.go
+++ b/pkg/handler/main_test.go
@@ -40,9 +40,10 @@ func Test_newFlag(t *testing.T) {
 				Type:      "bool",
 			},
 			exp: &cli.BoolFlag{
-				Name:    "foo, f",
+				Name:    "foo",
 				Usage:   "usage",
 				EnvVars: []string{"FOO"},
+				Aliases: []string{"f"},
 			},
 		},
 		{


### PR DESCRIPTION
A breaking change of urfave/cli v2

- v1: https://cli.urfave.org/v1/examples/flags/#alternate-names
- v2: https://cli.urfave.org/v2/examples/flags/#alternate-names