### PR TITLE
refactor: replace suzuki-shunsuke/go-timeout to exec.CommandContext, Cmd.Cancel, and Cmd.WaitDelay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/suzuki-shunsuke/go-cliutil v0.3.0
 	github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0
-	github.com/suzuki-shunsuke/go-timeout v1.0.0
 	github.com/urfave/cli/v2 v2.25.7
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,6 @@ github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMK
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
@@ -62,8 +61,6 @@ github.com/suzuki-shunsuke/go-cliutil v0.3.0 h1:nDMHCFT3LNShus5DxZ8FcHhnIrdqRH00
 github.com/suzuki-shunsuke/go-cliutil v0.3.0/go.mod h1:XdMIFYBkqjjXzLcAga1iKTbFKj4DunDXXmEqegz2HnY=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0 h1:oVXrrYNGBq4POyITQNWKzwsYz7B2nUcqtDbeX4BfeEc=
 github.com/suzuki-shunsuke/go-error-with-exit-code v1.0.0/go.mod h1:kDFtLeftDiIUUHXGI3xq5eJ+uAOi50FPrxPENTHktJ0=
-github.com/suzuki-shunsuke/go-timeout v1.0.0 h1:SWiJc8HuLWK4N01x76XUg75rbbwDiHiFoyPbwHcNI4Q=
-github.com/suzuki-shunsuke/go-timeout v1.0.0/go.mod h1:ZX3QIig4tvTVXnZUJE3ivC9qy5TJy9Uk5sIcvwjwSNE=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=

--- a/pkg/execute/execute.go
+++ b/pkg/execute/execute.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/suzuki-shunsuke/go-error-with-exit-code/ecerror"
-	"github.com/suzuki-shunsuke/go-timeout/timeout"
 )
 
 type Executor struct{}
@@ -33,12 +32,23 @@ type Timeout struct {
 	KillAfter time.Duration
 }
 
+func setCancel(cmd *exec.Cmd, waitDelay time.Duration) *exec.Cmd {
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(os.Interrupt) //nolint:wrapcheck
+	}
+	if waitDelay == 0 {
+		waitDelay = 1000 * time.Hour
+	}
+	cmd.WaitDelay = waitDelay
+	return cmd
+}
+
 func (exc *Executor) Run(ctx context.Context, params *Params) error {
 	shell := params.Shell
 	if len(shell) == 0 {
 		shell = []string{"sh", "-c"}
 	}
-	cmd := exec.Command(shell[0], append(shell[1:], params.Script)...) //nolint:gosec
+	cmd := exec.CommandContext(ctx, shell[0], append(shell[1:], params.Script)...) //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -51,10 +61,8 @@ func (exc *Executor) Run(ctx context.Context, params *Params) error {
 	if params.DryRun {
 		return nil
 	}
-	runner := timeout.NewRunner(params.Timeout.KillAfter)
-	runner.SetSigKillCaballback(func(targetID int) {
-		fmt.Fprintf(os.Stderr, "send SIGKILL to %d\n", targetID)
-	})
+
+	setCancel(cmd, params.Timeout.KillAfter)
 
 	if params.Timeout.Duration > 0 {
 		c, cancel := context.WithTimeout(ctx, params.Timeout.Duration)
@@ -68,7 +76,7 @@ func (exc *Executor) Run(ctx context.Context, params *Params) error {
 			fmt.Fprintf(os.Stderr, "command is terminated by timeout: %d seconds\n", params.Timeout.Duration)
 		}
 	}()
-	if err := runner.Run(ctx, cmd); err != nil {
+	if err := cmd.Run(); err != nil {
 		return ecerror.Wrap(err, cmd.ProcessState.ExitCode())
 	}
 	return nil


### PR DESCRIPTION
go-timeout was deprecated.

https://github.com/suzuki-shunsuke/go-timeout#warning-deprecated-go-120-has-supported-the-feature-officially