### PR TITLE
fix: `parent command [cmdx] has duplicated subcommand name or alias:`

### DIFF
--- a/pkg/handler/main.go
+++ b/pkg/handler/main.go
@@ -290,9 +290,13 @@ func convertTaskToCommand(task domain.Task, gFlags *domain.GlobalFlags) *cli.Com
 		for i, s := range task.Tasks {
 			tasks[i] = convertTaskToCommand(s, gFlags)
 		}
+		aliases := []string{}
+		if task.Short != "" {
+			aliases = []string{task.Short}
+		}
 		return &cli.Command{
 			Name:               task.Name,
-			Aliases:            []string{task.Short},
+			Aliases:            aliases,
 			Usage:              task.Usage,
 			Description:        task.Description,
 			Subcommands:        tasks,


### PR DESCRIPTION
Close #1045