### PR TITLE
feat: use bash as default shell with fallback to sh

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,10 @@ version: 2
 project_name: cmdx
 archives:
 - name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
+  format_overrides:
+  - goos: windows
+    formats:
+    - zip
 builds:
 - binary: cmdx
   main: cmd/cmdx/main.go

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ task.script_envs | []string | task level environment variable binding | false | 
 task.environment | map[string]string | the task's environment variables | false | {}
 task.script | string | the task command. This is run by `task.shell` | true |
 task.quiet | bool | task level default configuration whether the content of script is outputted | false |
-task.shell | []string | shell command to run the script | `["bash", "-c"]` (falls back to `["sh", "-c"]` if bash isn't available)
+task.shell | []string | shell command to run the script | `["bash", "-euo", "pipefail", "-c"]` (falls back to `["sh", "-c"]` if bash isn't available)
 task.timeout | timeout | the task command timeout | false |
 task.require | require | requirement of task | false | {}
 task.tasks | []task | sub tasks | false | `[]`
@@ -528,7 +528,7 @@ About prompt type, please see [AlecAivazis/survey's document](https://github.com
 
 **This is an advanced feature.**
 
-By default task's `script` is run by the command `bash -c` (or `sh -c` if bash isn't available).
+By default task's `script` is run by the command `bash -euo pipefail -c` (or `sh -c` if bash isn't available).
 You can change the command by the `shell` option.
 
 For example, you can run Python script.

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ task.args | []arg | the task positional arguments | false | []
 task.input_envs | []string | task level environment variable binding | false | []
 task.script_envs | []string | task level environment variable binding | false | []
 task.environment | map[string]string | the task's environment variables | false | {}
-task.script | string | the task command. This is run by `sh -c` | true |
+task.script | string | the task command. This is run by `bash -c` (or `sh -c` if bash isn't available) | true |
 task.quiet | bool | task level default configuration whether the content of script is outputted | false |
-task.shell | []string | shell command to run the script | `["sh", "-c"]`
+task.shell | []string | shell command to run the script | `["bash", "-c"]` (falls back to `["sh", "-c"]` if bash isn't available)
 task.timeout | timeout | the task command timeout | false |
 task.require | require | requirement of task | false | {}
 task.tasks | []task | sub tasks | false | `[]`
@@ -528,7 +528,7 @@ About prompt type, please see [AlecAivazis/survey's document](https://github.com
 
 **This is an advanced feature.**
 
-By default task's `script` is run by the command `sh -c`.
+By default task's `script` is run by the command `bash -c` (or `sh -c` if bash isn't available).
 You can change the command by the `shell` option.
 
 For example, you can run Python script.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ task.args | []arg | the task positional arguments | false | []
 task.input_envs | []string | task level environment variable binding | false | []
 task.script_envs | []string | task level environment variable binding | false | []
 task.environment | map[string]string | the task's environment variables | false | {}
-task.script | string | the task command. This is run by `bash -c` (or `sh -c` if bash isn't available) | true |
+task.script | string | the task command. This is run by `task.shell` | true |
 task.quiet | bool | task level default configuration whether the content of script is outputted | false |
 task.shell | []string | shell command to run the script | `["bash", "-c"]` (falls back to `["sh", "-c"]` if bash isn't available)
 task.timeout | timeout | the task command timeout | false |

--- a/pkg/execute/execute.go
+++ b/pkg/execute/execute.go
@@ -46,14 +46,12 @@ func setCancel(cmd *exec.Cmd, waitDelay time.Duration) *exec.Cmd {
 func (exc *Executor) Run(ctx context.Context, params *Params) error {
 	shell := params.Shell
 	if len(shell) == 0 {
-		// Try to use bash, fall back to sh if bash isn't available
-		shellCmd := "bash"
-		if _, err := exec.LookPath(shellCmd); err != nil {
-			shellCmd = "sh"
-			shell = []string{shellCmd, "-c"}
+		// Try to use bash with safer options, fall back to sh if bash isn't available
+		if _, err := exec.LookPath("bash"); err != nil {
+			shell = []string{"sh", "-c"}
 		} else {
 			// Use bash with safer options by default
-			shell = []string{shellCmd, "-euo", "pipefail", "-c"}
+			shell = []string{"bash", "-euo", "pipefail", "-c"}
 		}
 	}
 	cmd := exec.CommandContext(ctx, shell[0], append(shell[1:], params.Script)...) //nolint:gosec

--- a/pkg/execute/execute.go
+++ b/pkg/execute/execute.go
@@ -46,7 +46,12 @@ func setCancel(cmd *exec.Cmd, waitDelay time.Duration) *exec.Cmd {
 func (exc *Executor) Run(ctx context.Context, params *Params) error {
 	shell := params.Shell
 	if len(shell) == 0 {
-		shell = []string{"sh", "-c"}
+		// Try to use bash, fall back to sh if bash isn't available
+		shellCmd := "bash"
+		if _, err := exec.LookPath(shellCmd); err != nil {
+			shellCmd = "sh"
+		}
+		shell = []string{shellCmd, "-c"}
 	}
 	cmd := exec.CommandContext(ctx, shell[0], append(shell[1:], params.Script)...) //nolint:gosec
 	cmd.Stdout = os.Stdout

--- a/pkg/execute/execute.go
+++ b/pkg/execute/execute.go
@@ -50,8 +50,11 @@ func (exc *Executor) Run(ctx context.Context, params *Params) error {
 		shellCmd := "bash"
 		if _, err := exec.LookPath(shellCmd); err != nil {
 			shellCmd = "sh"
+			shell = []string{shellCmd, "-c"}
+		} else {
+			// Use bash with safer options by default
+			shell = []string{shellCmd, "-euo", "pipefail", "-c"}
 		}
-		shell = []string{shellCmd, "-c"}
 	}
 	cmd := exec.CommandContext(ctx, shell[0], append(shell[1:], params.Script)...) //nolint:gosec
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## ⚠️ Breaking Changes

The default shell is changed from `sh` to `bash -euo pipefail`.
If `bash` isn't available, sh is used.