### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,12 @@ on:
     tags: [v*]
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       aqua_version: v2.59.1
       go-version-file: go.mod
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test-main.yaml
+++ b/.github/workflows/test-main.yaml
@@ -11,7 +11,9 @@ jobs:
   test-main:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -19,4 +21,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: go test -v ./... -race -covermode=atomic

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read # To checkout private repository
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,20 +1,29 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read # To checkout private repository
+      id-token: write
 
   integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -22,5 +31,10 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: go install ./cmd/cmdx
       - run: cmdx help


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the CI workflows to guard against malicious dependencies during Go module downloads.

## Changes

- `.github/workflows/release.yaml`
  - Bump `go-release-workflow` ref `v8.0.0` -> `v8.1.0`.
  - Add `secrets.TAKUMI_GUARD_BOT_ID` to the `release` job.

- `.github/workflows/workflow_call_test.yaml`
  - Declare `TAKUMI_GUARD_BOT_ID` as a required secret under `on.workflow_call.secrets`.
  - Bump `go-test-full-workflow` ref `v5.0.2` -> `v6.0.0`, pass `secrets.TAKUMI_GUARD_BOT_ID`, and add `id-token: write` to the `test` job permissions.
  - In the `integration-test` job, add `contents: read` and `id-token: write` permissions, and insert the `flatt-security/setup-takumi-guard-golang@v1` step (with `bot-id`) after `setup-go` and before `go install`.

- `.github/workflows/test.yaml`
  - In the `test` job that calls the reusable `workflow_call_test.yaml`, pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write` to the permissions.

- `.github/workflows/test-main.yaml`
  - In the `test-main` job, set permissions to `contents: read` and `id-token: write`, and insert the `flatt-security/setup-takumi-guard-golang@v1` step (with `bot-id`) after `setup-go` and before `go test`.

## Note

`go-test-full-workflow` was bumped across a major version (`v5` -> `v6`). Please review CI for potential breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)